### PR TITLE
Pull request: redundant "definition", added italic to match amsthm and fixed a small issue in the readme (added a space)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Then, you can create definitions, theorems, and lemmas:
 \begin{definition}{The Name of The Defined}{label-name}
 	This is the body of the definition.
 	$$17 + 9$$
+	
 	_You **can** include styling and math in the body of the definition._
 \end{definition}
 ```

--- a/src/FranklinTheorems.jl
+++ b/src/FranklinTheorems.jl
@@ -49,7 +49,7 @@ module ExportConfigPath
 
 \\newenvironment{$(defn_name)}[2]{
 	\\stepcounter{Num$(defn_name)}
-	\\begin{thmBlock}{$(defn_titlecase) \\arabic{Num$(defn_name)}}{#1}{$(defn_titlecase)}{ \\fakebiblabel{!#2 @ $(defn_titlecase) \\arabic{Num$(defn_name)}} }
+	\\begin{thmBlock}{$(defn_titlecase) \\arabic{Num$(defn_name)}}{#1}{ \\fakebiblabel{!#2 @ $(defn_titlecase) \\arabic{Num$(defn_name)}} }
 }{
 	\\end{thmBlock}
 }

--- a/src/FranklinTheorems.md
+++ b/src/FranklinTheorems.md
@@ -1,12 +1,12 @@
 
 \newcommand{\franklinhtml}[1]{~~~!#1~~~}
 
-\newenvironment{thmBlock}[4]{
+\newenvironment{thmBlock}[3]{
 	\franklinhtml{
 		<div class="theorem">
-			<h2 class="theorem-header" id="}!#4\franklinhtml{">
+			<h2 class="theorem-header" id="}!#3\franklinhtml{">
 				<a href="#}!#4\franklinhtml{">}#1: #2\franklinhtml{</a>
-				<div class="theorem-type">}#3\franklinhtml{</div>
+				<div class="theorem-type">}\franklinhtml{</div>
 			</h2>
 			<div class="theorem-content">
 	}

--- a/src/FranklinTheorems.md
+++ b/src/FranklinTheorems.md
@@ -9,10 +9,11 @@
 				<div class="theorem-type">}\franklinhtml{</div>
 			</h2>
 			<div class="theorem-content">
+			<em>
 	}
 }
 {
-	\franklinhtml{
+	\franklinhtml{</em>
 		</div></div>
 	}
 }


### PR DESCRIPTION
Hi, 

Thanks for this cool package, I have started using it recently and I like it a lot. I made the following changes: 

1. In the current form (commit 2b0d607). The name of the environment shows up twice. See the image below 
<img width="589" alt="old_def" src="https://github.com/user-attachments/assets/808b7618-391e-4785-83d7-1044270306b8">

I removed this redundancy. Now, `thmBlock` has three inputs instead of 4. 

2. The example in the readme file needs a space before `_You **can** include styling ...` for the styling to work properly. 

3. The default `plain` style in [amsthm](https://ctan.org/pkg/amsthm?lang=en) typically writes text in italic. Now, the theorems and definitions are in italics by default.


Please let me know if you are interested in these changes or if you have any comments/concerns. I am also thinking of adding a fancy-ish theorem enviroment at some point like [xeboiboites](https://github.com/alexisflesch/xeboiboites). 